### PR TITLE
docs: update simulation instructions

### DIFF
--- a/development.md
+++ b/development.md
@@ -77,7 +77,7 @@ Finally, one can copy the files to the cluster that's running the health analyze
 ``` sh
 for d in data/*; do
   echo $d
-  kubectl cp $d openshift-user-workload-monitoring/prometheus-user-workload-0:/prometheus -c prometheus
+  kubectl cp $d openshift-monitoring/prometheus-k8s-0:/prometheus -c prometheus
 done
 ```
 


### PR DESCRIPTION
We moved to in-cluster prometheus, update the docs for simulation to match this change.