### PR TITLE
feat: rename src_silenced to silenced

### DIFF
--- a/pkg/processor/processor.go
+++ b/pkg/processor/processor.go
@@ -227,7 +227,7 @@ func (p *processor) evaluateSilences(alerts []model.LabelSet) ([]model.LabelSet,
 	}
 
 	// convert slice to temporary map for better lookup
-	silencedAlertsMap := make(map[string]struct{})
+	silencedAlertsMap := make(map[string]struct{}, len(silenced))
 	for _, silencedAlert := range silenced {
 		silencedAlertsMap[silencedAlert.Labels[AlertNameLabelKey]] = struct{}{}
 	}
@@ -235,10 +235,10 @@ func (p *processor) evaluateSilences(alerts []model.LabelSet) ([]model.LabelSet,
 	for i := range len(alerts) {
 		alertName := string(alerts[i][AlertNameLabelKey])
 		if _, f := silencedAlertsMap[alertName]; f {
-			alerts[i]["silenced"] = "1"
-			continue
+			alerts[i]["silenced"] = "true"
+		} else {
+			alerts[i]["silenced"] = "false"
 		}
-		alerts[i]["silenced"] = "0"
 	}
 
 	return alerts, nil

--- a/pkg/processor/processor_test.go
+++ b/pkg/processor/processor_test.go
@@ -246,12 +246,12 @@ func Test_evaluateSilences(t *testing.T) {
 				{
 					"alertname": "KubeNodeNotReady",
 					"namespace": "openshift-monitoring",
-					"silenced":  "0",
+					"silenced":  "false",
 				},
 				{
 					"alertname": "KubePodCrashLooping",
 					"namespace": "openshift-etcd",
-					"silenced":  "1",
+					"silenced":  "true",
 				},
 			},
 			wantErr: nil,

--- a/pkg/processor/types.go
+++ b/pkg/processor/types.go
@@ -96,6 +96,7 @@ func (c ComponentHealthMap) Labels() model.LabelSet {
 		"component": model.LabelValue(c.Component),
 		"type":      model.LabelValue(c.SrcType),
 		"group_id":  model.LabelValue(c.GroupId),
+		"silenced":  model.LabelValue(c.Silenced),
 	}
 
 	labels := make(model.LabelSet, len(c.SrcLabels)+len(metaLabels))
@@ -152,7 +153,7 @@ func evalMatcherFns(fns []componentMatcherFn, labels model.LabelSet) (
 
 // getLabelsSubset returns a subset of the labels with given keys.
 func getLabelsSubset(m model.LabelSet, keys ...model.LabelName) model.LabelSet {
-	keys = append([]model.LabelName{"namespace", "alertname", "severity", "silenced"}, keys...)
+	keys = append([]model.LabelName{"namespace", "alertname", "severity"}, keys...)
 	return getMapSubset(m, keys...)
 }
 


### PR DESCRIPTION
This PR introduces the following:

- rename label `src_silenced` to `silenced`
- minor code changes