### PR TITLE
fix: update the API server ciphersuites

### DIFF
--- a/cmd/serve/apiserver.go
+++ b/cmd/serve/apiserver.go
@@ -2,6 +2,7 @@ package serve
 
 import (
 	"context"
+	"crypto/tls"
 	"net/http"
 
 	configv1 "github.com/openshift/api/config/v1"
@@ -99,6 +100,17 @@ func buildServerConfig(o common.Options) (*genericapiserver.Config, error) {
 
 	// We will be serving out own `/metrics` endpoint.
 	serverConfig.EnableMetrics = false
+	// use only the secured cipher suites
+	serverConfig.SecureServing.CipherSuites = getCipherSuites()
 
 	return serverConfig, nil
+}
+
+func getCipherSuites() []uint16 {
+	secureCiphers := tls.CipherSuites()
+	cipherSuites := make([]uint16, len(secureCiphers))
+	for i, cipher := range secureCiphers {
+		cipherSuites[i] = cipher.ID
+	}
+	return cipherSuites
 }


### PR DESCRIPTION
This is to avoid:
```
W0916 08:29:24.990764 1 secure_serving.go:69] Use of insecure cipher 'TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256' detected.
W0916 08:29:24.990769 1 secure_serving.go:69] Use of insecure cipher 'TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256' detected.
W0916 08:29:24.990793 1 secure_serving.go:69] Use of insecure cipher 'TLS_RSA_WITH_AES_128_GCM_SHA256' detected.
W0916 08:29:24.990795 1 secure_serving.go:69] Use of insecure cipher 'TLS_RSA_WITH_AES_256_GCM_SHA384' detected.
W0916 08:29:24.990797 1 secure_serving.go:69] Use of insecure cipher 'TLS_RSA_WITH_AES_128_CBC_SHA' detected.
W0916 08:29:24.990798 1 secure_serving.go:69] Use of insecure cipher 'TLS_RSA_WITH_AES_256_CBC_SHA' detected.
```