### PR TITLE
fix: alertmanager loader using explicit params

### DIFF
--- a/pkg/alertmanager/loader.go
+++ b/pkg/alertmanager/loader.go
@@ -14,12 +14,12 @@ import (
 
 	runtimeclient "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
+	"github.com/openshift/cluster-health-analyzer/pkg/utils"
 	"github.com/prometheus/alertmanager/api/v2/client"
 	"github.com/prometheus/alertmanager/api/v2/client/alert"
 	"github.com/prometheus/alertmanager/api/v2/models"
 	"github.com/prometheus/client_golang/api"
 	prom_config "github.com/prometheus/common/config"
-	"k8s.io/utils/ptr"
 )
 
 // Loader reads alerts from the Alertmanager API
@@ -113,8 +113,8 @@ func (l *loader) loadAlerts(active, silenced bool, labels []string) ([]models.Al
 	params := alert.NewGetAlertsParams().
 		WithActive(&active).
 		WithSilenced(&silenced).
-		WithInhibited(ptr.To(false)).
-		WithUnprocessed(ptr.To(false)).
+		WithInhibited(utils.Ptr(false)).
+		WithUnprocessed(utils.Ptr(false)).
 		WithFilter(labels)
 
 	alertsOK, err := l.cli.Alert.GetAlerts(params)

--- a/pkg/utils/helpers.go
+++ b/pkg/utils/helpers.go
@@ -1,0 +1,6 @@
+package utils
+
+// Ptr is an helper function to return the pointer of any type
+func Ptr[T any](v T) *T {
+	return &v
+}


### PR DESCRIPTION
This is an edge case, but per https://github.com/prometheus/alertmanager/issues/1359 it's better to be explicit with all the params when filering alerts. 
I reproduced the strange situation when alert was returned as silenced (when actually was not. So I guess it was inhibited) with following steps:

1. Enable user workload monitoring in OpenShift with configmap:
```yaml
kind: ConfigMap
apiVersion: v1
metadata:
  name: cluster-monitoring-config
  namespace: openshift-monitoring
data:
  config.yaml: |
    enableUserWorkload: true
```
2. Create some testing alerts as:
```yaml
apiVersion: monitoring.coreos.com/v1
kind: PrometheusRule
metadata:
  name: testing2-prometheus-rule
  namespace: test2
spec:
  groups:
  - name: testing
    rules:
    - alert: TestingAlert7
      annotations:
        description: This is a testing alert
        summary: Always active alert with some labels.
      expr: vector(1)
      for: 10s
      labels:
        foo: bar
        severity: warning
        component: "testing-component"
    - alert: TestingAlert7
      annotations:
        description: This is a testing alert
        summary: Always active alert with some labels.
      expr: vector(1)
      for: 10s
      labels:
        foo: bar
        severity: critical
        test_label: second
```
The `TestingAlert7` with severity warning was marked as silenced in this case. 