### PR TITLE
COO-1591: add flags to override min TLS version & ciphersuites

### DIFF
--- a/cmd/serve/apiserver.go
+++ b/cmd/serve/apiserver.go
@@ -109,17 +109,21 @@ func buildServerConfig(o common.Options) (*genericapiserver.Config, error) {
 	}
 	serverConfig.SecureServing.MinTLSVersion = minVersion
 
-	cipherSuites, err := tlsCipherSuites(o.TLSCipherSuites)
-	if err != nil {
-		return nil, err
+	if len(o.TLSCipherSuites) > 0 {
+		cipherSuites, err := tlsCipherSuites(o.TLSCipherSuites)
+		if err != nil {
+			return nil, err
+		}
+		serverConfig.SecureServing.CipherSuites = cipherSuites
 	}
-	serverConfig.SecureServing.CipherSuites = cipherSuites
 
 	return serverConfig, nil
 }
 
 func tlsVersion(version string) (uint16, error) {
 	switch version {
+	case "":
+		return tls.VersionTLS12, nil
 	case "VersionTLS12":
 		return tls.VersionTLS12, nil
 	case "VersionTLS13":
@@ -130,15 +134,6 @@ func tlsVersion(version string) (uint16, error) {
 }
 
 func tlsCipherSuites(names []string) ([]uint16, error) {
-	if len(names) == 0 {
-		secureCiphers := tls.CipherSuites()
-		suites := make([]uint16, len(secureCiphers))
-		for i, c := range secureCiphers {
-			suites[i] = c.ID
-		}
-		return suites, nil
-	}
-
 	ciphersByName := map[string]uint16{}
 	for _, c := range tls.CipherSuites() {
 		ciphersByName[c.Name] = c.ID

--- a/cmd/serve/apiserver.go
+++ b/cmd/serve/apiserver.go
@@ -3,6 +3,7 @@ package serve
 import (
 	"context"
 	"crypto/tls"
+	"fmt"
 	"net/http"
 
 	configv1 "github.com/openshift/api/config/v1"
@@ -101,17 +102,55 @@ func buildServerConfig(o common.Options) (*genericapiserver.Config, error) {
 
 	// We will be serving out own `/metrics` endpoint.
 	serverConfig.EnableMetrics = false
-	// use only the secured cipher suites
-	serverConfig.SecureServing.CipherSuites = getCipherSuites()
+
+	minVersion, err := tlsVersion(o.TLSMinVersion)
+	if err != nil {
+		return nil, err
+	}
+	serverConfig.SecureServing.MinTLSVersion = minVersion
+
+	cipherSuites, err := tlsCipherSuites(o.TLSCipherSuites)
+	if err != nil {
+		return nil, err
+	}
+	serverConfig.SecureServing.CipherSuites = cipherSuites
 
 	return serverConfig, nil
 }
 
-func getCipherSuites() []uint16 {
-	secureCiphers := tls.CipherSuites()
-	cipherSuites := make([]uint16, len(secureCiphers))
-	for i, cipher := range secureCiphers {
-		cipherSuites[i] = cipher.ID
+func tlsVersion(version string) (uint16, error) {
+	switch version {
+	case "VersionTLS12":
+		return tls.VersionTLS12, nil
+	case "VersionTLS13":
+		return tls.VersionTLS13, nil
+	default:
+		return 0, fmt.Errorf("unsupported TLS version %q, must be one of: VersionTLS12, VersionTLS13", version)
 	}
-	return cipherSuites
+}
+
+func tlsCipherSuites(names []string) ([]uint16, error) {
+	if len(names) == 0 {
+		secureCiphers := tls.CipherSuites()
+		suites := make([]uint16, len(secureCiphers))
+		for i, c := range secureCiphers {
+			suites[i] = c.ID
+		}
+		return suites, nil
+	}
+
+	ciphersByName := map[string]uint16{}
+	for _, c := range tls.CipherSuites() {
+		ciphersByName[c.Name] = c.ID
+	}
+
+	suites := make([]uint16, 0, len(names))
+	for _, name := range names {
+		id, ok := ciphersByName[name]
+		if !ok {
+			return nil, fmt.Errorf("unsupported cipher suite %q", name)
+		}
+		suites = append(suites, id)
+	}
+	return suites, nil
 }

--- a/pkg/common/options.go
+++ b/pkg/common/options.go
@@ -15,6 +15,9 @@ type Options struct {
 	CertFile string
 	CertKey  string
 
+	TLSMinVersion  string
+	TLSCipherSuites []string
+
 	// Only to be used to for testing.
 	DisableAuthForTesting bool
 
@@ -42,6 +45,10 @@ func (o *Options) Flags() *pflag.FlagSet {
 
 	fs.StringVar(&o.CertFile, "tls-cert-file", "", "The path to the server certificate")
 	fs.StringVar(&o.CertKey, "tls-private-key-file", "", "The path to the server key")
+	fs.StringVar(&o.TLSMinVersion, "tls-min-version", "VersionTLS12",
+		"Minimum TLS version supported. Value must be one of: VersionTLS12, VersionTLS13")
+	fs.StringSliceVar(&o.TLSCipherSuites, "tls-cipher-suites", nil,
+		"Comma-separated list of cipher suites for the server. If omitted, the default secure cipher suites will be used")
 
 	fs.BoolVar(&o.DisableAuthForTesting, "disable-auth-for-testing", o.DisableAuthForTesting,
 		"Flag for testing purposes to disable auth")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--tls-min-version` command-line flag to configure minimum TLS version (TLS 1.2 and 1.3 supported)
  * Added `--tls-cipher-suites` flag to specify custom cipher suites for secure connections

<!-- end of auto-generated comment: release notes by coderabbit.ai -->