### PR TITLE
fix: bump up to Go 1.26

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25 as builder
+FROM golang:1.26 as builder
 ARG TARGETARCH
 
 WORKDIR /src

--- a/Dockerfile.konflux
+++ b/Dockerfile.konflux
@@ -1,4 +1,4 @@
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.25 as builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.26 as builder
 ARG TARGETARCH
 
 WORKDIR /src

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/cluster-health-analyzer
 
-go 1.25.0
+go 1.26
 
 require (
 	github.com/go-openapi/runtime v0.29.2


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the build environment to use Go 1.26.
  * Aligned the container-based build stages with the newer Go 1.26 builder image.
  * Bumped the project’s Go toolchain version to match the updated build setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->