### PR TITLE
[release-1.1] COO-1964: deduplicate health metrics to prevent /metrics HTTP 500

### DIFF
--- a/pkg/health/health_processor.go
+++ b/pkg/health/health_processor.go
@@ -155,7 +155,26 @@ func createHealthMetrics(componentHealth []*ComponentHealth) ([]prom.Metric, []p
 		objectMetrics = append(objectMetrics, oMetrics...)
 		componentMetrics = append(componentMetrics, cMetrics...)
 	}
-	return alertMetrics, objectMetrics, componentMetrics
+	return dedupMetrics(alertMetrics), dedupMetrics(objectMetrics), dedupMetrics(componentMetrics)
+}
+
+// dedupMetrics removes duplicate metrics that share the same label set.
+// For duplicates, the metric with the highest value (worst severity) is kept.
+func dedupMetrics(metrics []prom.Metric) []prom.Metric {
+	seen := make(map[model.Fingerprint]int, len(metrics))
+	deduped := make([]prom.Metric, 0, len(metrics))
+	for _, m := range metrics {
+		fp := m.Labels.Fingerprint()
+		if idx, ok := seen[fp]; ok {
+			if m.Value > deduped[idx].Value {
+				deduped[idx].Value = m.Value
+			}
+		} else {
+			seen[fp] = len(deduped)
+			deduped = append(deduped, m)
+		}
+	}
+	return deduped
 }
 
 // componentHealthMetrics creates list of alert, object and component metrics

--- a/pkg/health/health_processor_test.go
+++ b/pkg/health/health_processor_test.go
@@ -476,6 +476,42 @@ func TestComponentHealthsToMetrics(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "duplicate alerts with identical labels are deduplicated",
+			componentsHealth: []*ComponentHealth{
+				{
+					name:         "kubevirt",
+					healthStatus: Warning,
+					alerts: []model.LabelSet{
+						{
+							srcAlertname: "VMCannotBeEvicted",
+							srcSeverity:  "warning",
+							srcNamespace: "test-ns",
+							resource:     alertsVal,
+						},
+						{
+							srcAlertname: "VMCannotBeEvicted",
+							srcSeverity:  "warning",
+							srcNamespace: "test-ns",
+							resource:     alertsVal,
+						},
+					},
+				},
+			},
+			expectedAlertMetrics: []prom.Metric{
+				{
+					Labels: model.LabelSet{
+						"component":  "kubevirt",
+						srcAlertname: "VMCannotBeEvicted",
+						srcSeverity:  "warning",
+						srcNamespace: "test-ns",
+						resource:     alertsVal,
+						"status":     "warning",
+					},
+					Value: 1,
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -484,6 +520,72 @@ func TestComponentHealthsToMetrics(t *testing.T) {
 			assert.ElementsMatch(t, tt.expectedAlertMetrics, alertMetrics)
 			assert.ElementsMatch(t, tt.expectedComponentMetrics, componentMetrics)
 			assert.ElementsMatch(t, tt.expectedObjectMetrics, objectMetrics)
+		})
+	}
+}
+
+func TestDedupMetrics(t *testing.T) {
+	labels := model.LabelSet{
+		"component":  "kubevirt",
+		srcAlertname: "VMCannotBeEvicted",
+		srcSeverity:  "warning",
+		srcNamespace: "test-ns",
+		resource:     alertsVal,
+		"status":     "warning",
+	}
+
+	tests := []struct {
+		name     string
+		input    []prom.Metric
+		expected []prom.Metric
+	}{
+		{
+			name: "duplicates with same value are collapsed",
+			input: []prom.Metric{
+				{Labels: labels, Value: 1},
+				{Labels: labels, Value: 1},
+			},
+			expected: []prom.Metric{
+				{Labels: labels, Value: 1},
+			},
+		},
+		{
+			name: "duplicates keep highest value",
+			input: []prom.Metric{
+				{Labels: labels, Value: 1},
+				{Labels: labels, Value: 2},
+			},
+			expected: []prom.Metric{
+				{Labels: labels, Value: 2},
+			},
+		},
+		{
+			name: "duplicates keep highest value regardless of order",
+			input: []prom.Metric{
+				{Labels: labels, Value: 2},
+				{Labels: labels, Value: 1},
+			},
+			expected: []prom.Metric{
+				{Labels: labels, Value: 2},
+			},
+		},
+		{
+			name: "distinct metrics are preserved",
+			input: []prom.Metric{
+				{Labels: model.LabelSet{"component": "a"}, Value: 1},
+				{Labels: model.LabelSet{"component": "b"}, Value: 1},
+			},
+			expected: []prom.Metric{
+				{Labels: model.LabelSet{"component": "a"}, Value: 1},
+				{Labels: model.LabelSet{"component": "b"}, Value: 1},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := dedupMetrics(tt.input)
+			assert.ElementsMatch(t, tt.expected, result)
 		})
 	}
 }


### PR DESCRIPTION
When the same alert fires for multiple distinct resources in a namespace, cleanupLabels strips distinguishing labels, producing duplicate metrics with identical label sets. The Prometheus client library enforces uniqueness and panics during collection, causing the entire /metrics scrape to fail with HTTP 500.

Add dedupMetrics() that uses LabelSet.Fingerprint() to detect duplicates and keeps the metric with the worst severity. Apply it to all three metric types (alerts, objects, components) in createHealthMetrics().


Assisted-by: Claude Code:claude-opus-4-6