### PR TITLE
OBSINTA-1589: remove unnecessary rbac permissions for alertmanager API

### DIFF
--- a/manifests/backend/02_service_account.yaml
+++ b/manifests/backend/02_service_account.yaml
@@ -48,8 +48,6 @@ rules:
   - alertmanagers/api
   verbs:
   - get
-  - create
-  - update
 - apiGroups:
   - ""
   resources:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Restricted alert manager API access to read-only operations.
  * Removed permissions to create or update alert manager API resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->