### PR TITLE
feat: introduce TLS for MCP + TokenReviewer 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ run:
 ## run-mcp> run the mcp server locally (requires prometheus and alertmanager running)
 .PHONY: run-mcp
 run-mcp:
-	go run ./main.go mcp
+	go run ./main.go mcp --disable-auth-for-testing
 
 ## generate> run go generate
 .PHONY: generate

--- a/cmd/mcp/serve.go
+++ b/cmd/mcp/serve.go
@@ -15,10 +15,11 @@ var (
 )
 
 var (
-	promURL         string
-	alertManagerURL string
-	tlsCertFile     string
-	tlsKeyFile      string
+	promURL                string
+	alertManagerURL        string
+	tlsCertFile            string
+	tlsKeyFile             string
+	disableAuthForTesting  bool
 )
 
 var (
@@ -44,18 +45,23 @@ var (
 			}
 
 			serverCfg := mcp.MCPHealthServerCfg{
-				Name:            MCPServerName,
-				Version:         MCPServerVersion,
-				Url:             ":8085",
-				PrometheusURL:   promURL,
-				AlertManagerURL: alertManagerURL,
-				TLSCertFile:     tlsCertFile,
-				TLSKeyFile:      tlsKeyFile,
+				Name:                 MCPServerName,
+				Version:              MCPServerVersion,
+				Url:                  ":8085",
+				PrometheusURL:        promURL,
+				AlertManagerURL:      alertManagerURL,
+				TLSCertFile:          tlsCertFile,
+				TLSKeyFile:           tlsKeyFile,
+				DisableAuthForTesting: disableAuthForTesting,
 			}
 
-			server := mcp.NewMCPHealthServer(serverCfg)
+			server, err := mcp.NewMCPHealthServer(serverCfg)
+			if err != nil {
+				slog.Error("Failed to initialize the MCP server", "error", err)
+				return
+			}
 
-			err := server.Start()
+			err = server.Start()
 			if err != nil {
 				slog.Error("Failed to start the MCP server", "error", err)
 				return
@@ -69,4 +75,5 @@ func init() {
 	MCPCmd.Flags().StringVar(&alertManagerURL, "alertmanager-url", "", "URL of the AlertManager server")
 	MCPCmd.Flags().StringVar(&tlsCertFile, "tls-cert-file", "", "Path to the TLS certificate file")
 	MCPCmd.Flags().StringVar(&tlsKeyFile, "tls-private-key-file", "", "Path to the TLS private key file")
+	MCPCmd.Flags().BoolVar(&disableAuthForTesting, "disable-auth-for-testing", false, "Disable token authentication (for local development only)")
 }

--- a/cmd/mcp/serve.go
+++ b/cmd/mcp/serve.go
@@ -17,6 +17,8 @@ var (
 var (
 	promURL         string
 	alertManagerURL string
+	tlsCertFile     string
+	tlsKeyFile      string
 )
 
 var (
@@ -47,6 +49,8 @@ var (
 				Url:             ":8085",
 				PrometheusURL:   promURL,
 				AlertManagerURL: alertManagerURL,
+				TLSCertFile:     tlsCertFile,
+				TLSKeyFile:      tlsKeyFile,
 			}
 
 			server := mcp.NewMCPHealthServer(serverCfg)
@@ -63,4 +67,6 @@ var (
 func init() {
 	MCPCmd.Flags().StringVarP(&promURL, "prom-url", "u", "", "URL of the Prometheus server")
 	MCPCmd.Flags().StringVar(&alertManagerURL, "alertmanager-url", "", "URL of the AlertManager server")
+	MCPCmd.Flags().StringVar(&tlsCertFile, "tls-cert-file", "", "Path to the TLS certificate file")
+	MCPCmd.Flags().StringVar(&tlsKeyFile, "tls-private-key-file", "", "Path to the TLS private key file")
 }

--- a/manifests/mcp/02_deployment.yaml
+++ b/manifests/mcp/02_deployment.yaml
@@ -18,12 +18,22 @@ spec:
     spec:
       serviceAccountName: cluster-health-analyzer-mcp-thanos-querier
       automountServiceAccountToken: true
+      volumes:
+        - name: tls-certs
+          secret:
+            secretName: cluster-health-analyzer-mcp-tls
       containers:
       - name: cluster-health-mcp-server
-        image: "quay.io/openshiftanalytics/cluster-health-analyzer:mcp-dev-preview"
+        image: "quay.io/rh-ee-criolo/cluster-health-analyzer:mcp-tls"
+        volumeMounts:
+          - name: tls-certs
+            mountPath: /etc/tls/private
+            readOnly: true
         imagePullPolicy: Always
         args:
           - mcp
+          - --tls-cert-file=/etc/tls/private/tls.crt
+          - --tls-private-key-file=/etc/tls/private/tls.key
         env:
           - name: PROM_URL
             value: "https://thanos-querier.openshift-monitoring.svc.cluster.local:9091/"

--- a/manifests/mcp/02_deployment.yaml
+++ b/manifests/mcp/02_deployment.yaml
@@ -24,7 +24,7 @@ spec:
             secretName: cluster-health-analyzer-mcp-tls
       containers:
       - name: cluster-health-mcp-server
-        image: "quay.io/rh-ee-criolo/cluster-health-analyzer:mcp-tls"
+        image: "quay.io/openshiftanalytics/cluster-health-analyzer:mcp-dev-preview"
         volumeMounts:
           - name: tls-certs
             mountPath: /etc/tls/private

--- a/manifests/mcp/02_deployment.yaml
+++ b/manifests/mcp/02_deployment.yaml
@@ -22,6 +22,8 @@ spec:
         - name: tls-certs
           secret:
             secretName: cluster-health-analyzer-mcp-tls
+        - name: tmp
+          emptyDir: {}
       containers:
       - name: cluster-health-mcp-server
         image: "quay.io/openshiftanalytics/cluster-health-analyzer:mcp-dev-preview"
@@ -29,6 +31,8 @@ spec:
           - name: tls-certs
             mountPath: /etc/tls/private
             readOnly: true
+          - name: tmp
+            mountPath: /tmp
         imagePullPolicy: Always
         args:
           - mcp
@@ -39,8 +43,16 @@ spec:
             value: "https://thanos-querier.openshift-monitoring.svc.cluster.local:9091/"
           - name: ALERTMANAGER_URL
             value: "https://alertmanager-main.openshift-monitoring.svc.cluster.local:9094"
+        resources:
+          requests:
+            cpu: 10m
+            memory: 64Mi
+          limits:
+            cpu: 100m
+            memory: 128Mi
         securityContext:
           runAsNonRoot: true
+          readOnlyRootFilesystem: true
           allowPrivilegeEscalation: false
           capabilities:
             drop: ["ALL"]

--- a/manifests/mcp/03_mcp_service.yaml
+++ b/manifests/mcp/03_mcp_service.yaml
@@ -5,6 +5,8 @@ metadata:
     app.kubernetes.io/name: cluster-health-analyzer-mcp
   name: cluster-health-mcp-server
   namespace: openshift-cluster-observability-operator
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: "cluster-health-analyzer-mcp-tls"
 spec:
   ports:
   - name: mcp

--- a/pkg/mcp/auth.go
+++ b/pkg/mcp/auth.go
@@ -1,0 +1,41 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+
+	authenticationv1 "k8s.io/api/authentication/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// TokenReviewer validates bearer tokens using the Kubernetes TokenReview API.
+type TokenReviewer struct {
+	client kubernetes.Interface
+}
+
+// NewTokenReviewer creates a TokenReviewer with the given Kubernetes client.
+func NewTokenReviewer(client kubernetes.Interface) *TokenReviewer {
+	return &TokenReviewer{client: client}
+}
+
+// ValidateToken submits a TokenReview for the given token and returns an
+// error when the token is invalid or nil when the token is authenticated.
+func (t *TokenReviewer) ValidateToken(ctx context.Context, token string) error {
+	review := &authenticationv1.TokenReview{
+		Spec: authenticationv1.TokenReviewSpec{
+			Token: token,
+		},
+	}
+
+	result, err := t.client.AuthenticationV1().TokenReviews().Create(ctx, review, metav1.CreateOptions{})
+	if err != nil {
+		return fmt.Errorf("token review request failed: %w", err)
+	}
+
+	if !result.Status.Authenticated {
+		return fmt.Errorf("token authentication failed: %s", result.Status.Error)
+	}
+
+	return nil
+}

--- a/pkg/mcp/auth_test.go
+++ b/pkg/mcp/auth_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestValidateToken_Authenticated(t *testing.T) {
-	client := fake.NewSimpleClientset()
+	client := fake.NewClientset()
 	client.PrependReactor("create", "tokenreviews", func(action k8stesting.Action) (bool, runtime.Object, error) {
 		review := action.(k8stesting.CreateAction).GetObject().(*authenticationv1.TokenReview)
 		review.Status = authenticationv1.TokenReviewStatus{
@@ -30,7 +30,7 @@ func TestValidateToken_Authenticated(t *testing.T) {
 }
 
 func TestValidateToken_Unauthenticated(t *testing.T) {
-	client := fake.NewSimpleClientset()
+	client := fake.NewClientset()
 	client.PrependReactor("create", "tokenreviews", func(action k8stesting.Action) (bool, runtime.Object, error) {
 		review := action.(k8stesting.CreateAction).GetObject().(*authenticationv1.TokenReview)
 		review.Status = authenticationv1.TokenReviewStatus{

--- a/pkg/mcp/auth_test.go
+++ b/pkg/mcp/auth_test.go
@@ -1,0 +1,47 @@
+package mcp
+
+import (
+	"context"
+	"testing"
+
+	authenticationv1 "k8s.io/api/authentication/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+func TestValidateToken_Authenticated(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	client.PrependReactor("create", "tokenreviews", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		review := action.(k8stesting.CreateAction).GetObject().(*authenticationv1.TokenReview)
+		review.Status = authenticationv1.TokenReviewStatus{
+			Authenticated: true,
+			User: authenticationv1.UserInfo{
+				Username: "test-user",
+			},
+		}
+		return true, review, nil
+	})
+
+	reviewer := NewTokenReviewer(client)
+	if err := reviewer.ValidateToken(context.Background(), "valid-token"); err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+}
+
+func TestValidateToken_Unauthenticated(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	client.PrependReactor("create", "tokenreviews", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		review := action.(k8stesting.CreateAction).GetObject().(*authenticationv1.TokenReview)
+		review.Status = authenticationv1.TokenReviewStatus{
+			Authenticated: false,
+			Error:         "token expired",
+		}
+		return true, review, nil
+	})
+
+	reviewer := NewTokenReviewer(client)
+	if err := reviewer.ValidateToken(context.Background(), "expired-token"); err == nil {
+		t.Fatal("expected error for unauthenticated token, got nil")
+	}
+}

--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -104,12 +104,10 @@ func (m *MCPHealthServer) Start() error {
 			if m.tokenReviewer != nil {
 				token, err := getTokenFromCtx(authCtx)
 				if err != nil {
-					slog.Error("Missing authentication token", "error", err)
 					http.Error(w, "Unauthorized", http.StatusUnauthorized)
 					return
 				}
 				if err := m.tokenReviewer.ValidateToken(r.Context(), token); err != nil {
-					slog.Error("Token validation failed", "error", err)
 					http.Error(w, "Unauthorized", http.StatusUnauthorized)
 					return
 				}
@@ -121,6 +119,10 @@ func (m *MCPHealthServer) Start() error {
 	}
 
 	handlerWithAuthCtx := mdw(handler)
+
+	if (m.tlsCertFile == "") != (m.tlsKeyFile == "") {
+		return errors.New("both TLS certificate and private key files must be configured")
+	}
 
 	if m.tlsCertFile != "" && m.tlsKeyFile != "" {
 		slog.Info("TLS enabled for MCP server")

--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"log/slog"
 	"net/http"
@@ -18,8 +19,10 @@ const authHeaderStr authHeader = "kubernetes-authorization"
 // providing basic methods to run the underlying SSE server
 // and to register tools
 type MCPHealthServer struct {
-	server *mcp.Server
-	addr   string
+	server      *mcp.Server
+	addr        string
+	tlsCertFile string
+	tlsKeyFile  string
 }
 
 type MCPHealthServerCfg struct {
@@ -29,6 +32,9 @@ type MCPHealthServerCfg struct {
 
 	PrometheusURL   string
 	AlertManagerURL string
+
+	TLSCertFile string
+	TLSKeyFile  string
 }
 
 // NewMCPHealthServer returns an instance of the MCPHealthServer
@@ -45,8 +51,10 @@ func NewMCPHealthServer(cfg MCPHealthServerCfg) *MCPHealthServer {
 	mcp.AddTool(server, &incTool.Tool, mcp.ToolHandlerFor[GetIncidentsParams, any](incTool.IncidentsHandler))
 
 	return &MCPHealthServer{
-		server: server,
-		addr:   cfg.Url,
+		server:      server,
+		addr:        cfg.Url,
+		tlsCertFile: cfg.TLSCertFile,
+		tlsKeyFile:  cfg.TLSKeyFile,
 	}
 }
 
@@ -72,6 +80,20 @@ func (m *MCPHealthServer) Start() error {
 	}
 
 	handlerWithAuthCtx := mdw(handler)
+
+	if m.tlsCertFile != "" && m.tlsKeyFile != "" {
+		slog.Info("TLS enabled for MCP server")
+		tlsServer := &http.Server{
+			Addr:    m.addr,
+			Handler: handlerWithAuthCtx,
+			TLSConfig: &tls.Config{
+				MinVersion: tls.VersionTLS12,
+			},
+		}
+		return tlsServer.ListenAndServeTLS(m.tlsCertFile, m.tlsKeyFile)
+	}
+
+	slog.Warn("TLS is not configured, serving over plaintext HTTP")
 	return http.ListenAndServe(m.addr, handlerWithAuthCtx)
 }
 

--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 )
 
 type authHeader string
@@ -19,10 +21,11 @@ const authHeaderStr authHeader = "kubernetes-authorization"
 // providing basic methods to run the underlying SSE server
 // and to register tools
 type MCPHealthServer struct {
-	server      *mcp.Server
-	addr        string
-	tlsCertFile string
-	tlsKeyFile  string
+	server        *mcp.Server
+	addr          string
+	tlsCertFile   string
+	tlsKeyFile    string
+	tokenReviewer *TokenReviewer
 }
 
 type MCPHealthServerCfg struct {
@@ -35,10 +38,14 @@ type MCPHealthServerCfg struct {
 
 	TLSCertFile string
 	TLSKeyFile  string
+
+	// DisableAuthForTesting skips TokenReview validation.
+	// Only intended for local development.
+	DisableAuthForTesting bool
 }
 
 // NewMCPHealthServer returns an instance of the MCPHealthServer
-func NewMCPHealthServer(cfg MCPHealthServerCfg) *MCPHealthServer {
+func NewMCPHealthServer(cfg MCPHealthServerCfg) (*MCPHealthServer, error) {
 	impl := mcp.Implementation{
 		Name:    cfg.Name,
 		Version: cfg.Version,
@@ -50,12 +57,29 @@ func NewMCPHealthServer(cfg MCPHealthServerCfg) *MCPHealthServer {
 	// get_incidents
 	mcp.AddTool(server, &incTool.Tool, mcp.ToolHandlerFor[GetIncidentsParams, any](incTool.IncidentsHandler))
 
-	return &MCPHealthServer{
-		server:      server,
-		addr:        cfg.Url,
-		tlsCertFile: cfg.TLSCertFile,
-		tlsKeyFile:  cfg.TLSKeyFile,
+	var reviewer *TokenReviewer
+	if !cfg.DisableAuthForTesting {
+		restCfg, err := rest.InClusterConfig()
+		if err != nil {
+			return nil, errors.Join(errors.New("failed to build in-cluster config for token review"), err)
+		}
+		clientset, err := kubernetes.NewForConfig(restCfg)
+		if err != nil {
+			return nil, errors.Join(errors.New("failed to create kubernetes client for token review"), err)
+		}
+		reviewer = NewTokenReviewer(clientset)
+		slog.Info("TokenReview authentication enabled")
+	} else {
+		slog.Warn("Authentication is disabled — do not use in production")
 	}
+
+	return &MCPHealthServer{
+		server:        server,
+		addr:          cfg.Url,
+		tlsCertFile:   cfg.TLSCertFile,
+		tlsKeyFile:    cfg.TLSKeyFile,
+		tokenReviewer: reviewer,
+	}, nil
 }
 
 // Start runs the MCPHealthServer
@@ -70,10 +94,27 @@ func (m *MCPHealthServer) Start() error {
 	slog.Info("Starting MCP server on ", "address", m.addr)
 
 	// the following middleware is needed to enrich the context that will be
-	// forwarded until the mcp server with the kubernetes-authorization token
+	// forwarded until the mcp server with the kubernetes-authorization token.
+	// When a TokenReviewer is configured, the token is validated via the
+	// Kubernetes TokenReview API before the request is forwarded.
 	mdw := func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			authCtx := authFromRequest(r.Context(), r)
+
+			if m.tokenReviewer != nil {
+				token, err := getTokenFromCtx(authCtx)
+				if err != nil {
+					slog.Error("Missing authentication token", "error", err)
+					http.Error(w, "Unauthorized", http.StatusUnauthorized)
+					return
+				}
+				if err := m.tokenReviewer.ValidateToken(r.Context(), token); err != nil {
+					slog.Error("Token validation failed", "error", err)
+					http.Error(w, "Unauthorized", http.StatusUnauthorized)
+					return
+				}
+			}
+
 			r = r.WithContext(authCtx)
 			next.ServeHTTP(w, r)
 		})


### PR DESCRIPTION
This PR addresses the following security issues:

- cluster-health-analyzer-mcp was exposed as plain HTTP
- No token validation was performed by the cluster-health-analyzer but only demanded to Thanos/Alertmanager. If the token is invalid this is not forwarded.

Assisted-By: Claude

