### PR TITLE
feat: add support for liveness/readiness probes

### DIFF
--- a/manifests/backend/05_deployment.yaml
+++ b/manifests/backend/05_deployment.yaml
@@ -41,6 +41,22 @@ spec:
         ports:
         - containerPort: 8443
           name: metrics
+        livenessProbe:
+          httpGet:
+            path: /livez
+            port: metrics
+            scheme: HTTPS
+          initialDelaySeconds: 15
+          periodSeconds: 20
+          timeoutSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: metrics
+            scheme: HTTPS
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 5
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/tls/private

--- a/manifests/mcp/02_deployment.yaml
+++ b/manifests/mcp/02_deployment.yaml
@@ -61,4 +61,20 @@ spec:
         ports:
         - containerPort: 8085
           name: mcp
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: mcp
+            scheme: HTTPS
+          initialDelaySeconds: 15
+          periodSeconds: 20
+          timeoutSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: mcp
+            scheme: HTTPS
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 5
         terminationMessagePolicy: FallbackToLogsOnError

--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"strings"
@@ -82,43 +83,36 @@ func NewMCPHealthServer(cfg MCPHealthServerCfg) (*MCPHealthServer, error) {
 	}, nil
 }
 
+// handler builds the root http.Handler for the MCP server, registering the
+// healthz endpoint outside the auth middleware and routing everything else
+// through it.
+func (m *MCPHealthServer) handler() http.Handler {
+	mcpHandler := mcp.NewStreamableHTTPHandler(func(r *http.Request) *mcp.Server {
+		return m.server
+	}, nil)
+
+	mux := http.NewServeMux()
+
+	// Register the healthz endpoint directly on the mux, outside the
+	// auth middleware, so that kubelet probes can reach it without
+	// a bearer token.
+	mux.HandleFunc("/healthz", healthzHandler)
+
+	// All other paths go through the auth middleware.
+	mux.Handle("/", m.authMiddleware(mcpHandler))
+
+	return mux
+}
+
 // Start runs the MCPHealthServer
 func (m *MCPHealthServer) Start() error {
 	if m.addr == "" {
 		return errors.New("empty http address")
 	}
-	handler := mcp.NewStreamableHTTPHandler(func(r *http.Request) *mcp.Server {
-		return m.server
-	}, nil)
 
 	slog.Info("Starting MCP server on ", "address", m.addr)
 
-	// the following middleware is needed to enrich the context that will be
-	// forwarded until the mcp server with the kubernetes-authorization token.
-	// When a TokenReviewer is configured, the token is validated via the
-	// Kubernetes TokenReview API before the request is forwarded.
-	mdw := func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			authCtx := authFromRequest(r.Context(), r)
-
-			if m.tokenReviewer != nil {
-				token, err := getTokenFromCtx(authCtx)
-				if err != nil {
-					http.Error(w, "Unauthorized", http.StatusUnauthorized)
-					return
-				}
-				if err := m.tokenReviewer.ValidateToken(r.Context(), token); err != nil {
-					http.Error(w, "Unauthorized", http.StatusUnauthorized)
-					return
-				}
-			}
-
-			r = r.WithContext(authCtx)
-			next.ServeHTTP(w, r)
-		})
-	}
-
-	handlerWithAuthCtx := mdw(handler)
+	h := m.handler()
 
 	if (m.tlsCertFile == "") != (m.tlsKeyFile == "") {
 		return errors.New("both TLS certificate and private key files must be configured")
@@ -128,7 +122,7 @@ func (m *MCPHealthServer) Start() error {
 		slog.Info("TLS enabled for MCP server")
 		tlsServer := &http.Server{
 			Addr:    m.addr,
-			Handler: handlerWithAuthCtx,
+			Handler: h,
 			TLSConfig: &tls.Config{
 				MinVersion: tls.VersionTLS12,
 			},
@@ -137,12 +131,46 @@ func (m *MCPHealthServer) Start() error {
 	}
 
 	slog.Warn("TLS is not configured, serving over plaintext HTTP")
-	return http.ListenAndServe(m.addr, handlerWithAuthCtx)
+	return http.ListenAndServe(m.addr, h)
 }
 
 // RegisterTool registers a new tool on the MCPHealthServer
 func (m *MCPHealthServer) RegisterTool(t *mcp.Tool, handler mcp.ToolHandlerFor[any, any]) {
 	mcp.AddTool(m.server, t, handler)
+}
+
+// healthzHandler responds with 200 OK for liveness and readiness probes.
+func healthzHandler(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	w.WriteHeader(http.StatusOK)
+	if _, err := fmt.Fprintln(w, "ok"); err != nil {
+		slog.Debug("healthz: failed to write response", "err", err)
+	}
+}
+
+// authMiddleware returns an http.Handler that enriches the request context
+// with the kubernetes-authorization token. When a TokenReviewer is configured,
+// the token is validated via the Kubernetes TokenReview API before the
+// request is forwarded.
+func (m *MCPHealthServer) authMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authCtx := authFromRequest(r.Context(), r)
+
+		if m.tokenReviewer != nil {
+			token, err := getTokenFromCtx(authCtx)
+			if err != nil {
+				http.Error(w, "Unauthorized", http.StatusUnauthorized)
+				return
+			}
+			if err := m.tokenReviewer.ValidateToken(r.Context(), token); err != nil {
+				http.Error(w, "Unauthorized", http.StatusUnauthorized)
+				return
+			}
+		}
+
+		r = r.WithContext(authCtx)
+		next.ServeHTTP(w, r)
+	})
 }
 
 func authFromRequest(ctx context.Context, r *http.Request) context.Context {

--- a/pkg/mcp/server_test.go
+++ b/pkg/mcp/server_test.go
@@ -1,0 +1,106 @@
+package mcp
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	authenticationv1 "k8s.io/api/authentication/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+// newFakeReviewer returns a TokenReviewer backed by a fake clientset that
+// always rejects tokens.
+func newFakeReviewer() *TokenReviewer {
+	client := fake.NewClientset()
+	client.PrependReactor("create", "tokenreviews", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		review := action.(k8stesting.CreateAction).GetObject().(*authenticationv1.TokenReview)
+		review.Status = authenticationv1.TokenReviewStatus{
+			Authenticated: false,
+			Error:         "fake: always reject",
+		}
+		return true, review, nil
+	})
+	return NewTokenReviewer(client)
+}
+
+// TestHealthzBypassesAuth verifies that /healthz is reachable without
+// authentication, while the MCP endpoint (catch-all) correctly rejects
+// unauthenticated requests.
+func TestHealthzBypassesAuth(t *testing.T) {
+	cfg := MCPHealthServerCfg{
+		Name:                  "test-mcp",
+		Version:               "0.0.1-test",
+		Url:                   ":0", // unused; we use httptest
+		PrometheusURL:         "http://localhost:9090",
+		AlertManagerURL:       "http://localhost:9093",
+		DisableAuthForTesting: true, // skip in-cluster config
+	}
+
+	srv, err := NewMCPHealthServer(cfg)
+	if err != nil {
+		t.Fatalf("failed to create MCP server: %v", err)
+	}
+
+	// Attach a reviewer that always rejects tokens so we can verify
+	// that healthz paths are truly exempt from auth.
+	srv.tokenReviewer = newFakeReviewer()
+
+	ts := httptest.NewServer(srv.handler())
+	t.Cleanup(ts.Close)
+
+	baseURL := ts.URL
+
+	// /healthz must be reachable without a token.
+	t.Run("unauthenticated /healthz", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+"/healthz", nil)
+		if err != nil {
+			t.Fatalf("failed to create request: %v", err)
+		}
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("GET /healthz failed: %v", err)
+		}
+
+		defer func() {
+			_ = resp.Body.Close()
+		}()
+
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("GET /healthz: expected 200, got %d", resp.StatusCode)
+		}
+	})
+
+	// The MCP catch-all must reject unauthenticated requests.
+	t.Run("unauthenticated /mcp", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, baseURL+"/mcp", nil)
+		if err != nil {
+			t.Fatalf("failed to create request: %v", err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("POST /mcp failed: %v", err)
+		}
+
+		defer func() {
+			_ = resp.Body.Close()
+		}()
+
+		if resp.StatusCode != http.StatusUnauthorized {
+			t.Errorf("POST /mcp: expected 401, got %d", resp.StatusCode)
+		}
+	})
+}


### PR DESCRIPTION
As title this PR introduces liveness and readiness probe for both CHA backend and mcp

Assisted-By: Claude

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a publicly accessible MCP health-check endpoint that returns a successful response.
  * Added authentication enforcement for MCP requests while keeping health checks publicly accessible.

* **Reliability**
  * Added HTTPS liveness and readiness probes for backend and MCP services.
  * Configured startup delays, polling intervals, and timeouts to improve detection of unhealthy or unavailable instances.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->